### PR TITLE
feat: implement new parameters api, make cli --help work and notify user on page errors that occured while processing stories for Steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "storywright",
   "description": "Storybook setup.",
   "license": "MIT",
-  "version": "0.0.27-storybook7.11",
+  "version": "0.0.27-storybook7.12",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/StoryWright/Steps.ts
+++ b/src/StoryWright/Steps.ts
@@ -229,6 +229,10 @@ export interface Step {
   isEnabled?: boolean;
 }
 
-export interface StoryParameter {
-  storyWright: { steps: Step[] };
+interface Parameters {
+ [name: string]: any
+}
+
+export interface StoryParameters extends Parameters {
+  storyWright?: { steps: Step[] };
 }

--- a/src/StoryWright/Steps.ts
+++ b/src/StoryWright/Steps.ts
@@ -5,7 +5,6 @@ type optionsObj = {
   [key: string]: unknown;
 };
 
-
 export class Steps {
   steps: Step[] = [];
 
@@ -228,4 +227,8 @@ export interface Step {
   isAsync?: boolean;
   waitTime?: number;
   isEnabled?: boolean;
+}
+
+export interface StoryParameter {
+  storyWright: { steps: Step[] };
 }

--- a/src/StoryWrightProcessor/GetStories.js
+++ b/src/StoryWrightProcessor/GetStories.js
@@ -11,14 +11,7 @@
             }} SbFeatures
 */
 
-/**
- * @typedef {{
-   id:string;
-   parameters?: {[name: string]: any} & Partial<import('../StoryWright/Steps').StoryParameter>;
-   storyFn?: ()=>unknown;
-   [key:string]:unknown;
-  }} Story
- */
+
 
 getStoriesWithSteps();
 
@@ -46,8 +39,8 @@ function getStoriesWithSteps() {
           }
         } else if (usesOldStoryFnCall(story)) {
           let res = story.storyFn();
-          let steps = findSteps(res);
-          if (steps !== "undefined" && steps !== null) {
+          const steps = findSteps(res);
+          if (steps !== undefined && steps !== null) {
             story.steps = steps;
           }
         }
@@ -66,7 +59,7 @@ function getStoriesWithSteps() {
 
 /**
  *
- * @param {Story} story
+ * @param {import('../utils').Story} story
  * @returns
  */
 function usesNewParametersApi(story) {
@@ -74,7 +67,7 @@ function usesNewParametersApi(story) {
 }
 /**
  *
- * @param {Story} story
+ * @param {import('../utils').Story} story
  * @returns
  */
 function usesOldStoryFnCall(story) {
@@ -84,7 +77,7 @@ function usesOldStoryFnCall(story) {
 /**
  *
  * @param {Record<string,any>} res
- * @returns
+ * @returns {import('../utils').Story['steps'] | undefined}
  */
 function findSteps(res) {
   if (res.props && res.props.isStowrWrightComponent === true) {
@@ -111,7 +104,7 @@ function findSteps(res) {
 /**
  *
  * @param {SbFeatures} features
- * @returns {Promise<Array<Story>>}
+ * @returns {Promise<Array<import('../utils').Story>>}
  */
 function getPageStories(features) {
   /**

--- a/src/StoryWrightProcessor/GetStories.js
+++ b/src/StoryWrightProcessor/GetStories.js
@@ -20,7 +20,14 @@ function getStoriesWithSteps() {
   const storybookFeatures = window["FEATURES"];
 
   return getPageStories(storybookFeatures).then((stories) => {
-    let ret = [];
+    /**
+     * @type {typeof stories}
+     */
+    const storiesWithSteps = [];
+    /**
+     * @type {string[]} story ids that failed while processing storyFn
+     */
+    const errors = [];
     for (let story of stories) {
       try {
         if (typeof story.storyFn === "function") {
@@ -31,13 +38,15 @@ function getStoriesWithSteps() {
           }
         }
       } catch (ex) {
-        console.error("Error processing render() method of:", story["id"]);
+        errors.push(story["id"]);
+        console.error("Error processing render() method of: " + story["id"]);
         console.error(ex);
       }
-      ret.push(story);
+
+      storiesWithSteps.push(story);
     }
 
-    return ret;
+    return { storiesWithSteps, errors };
   });
 }
 
@@ -71,7 +80,7 @@ function findSteps(res) {
 /**
  *
  * @param {SbFeatures} features
- * @returns {Promise<Array<Record<string,unknown>>>}
+ * @returns {Promise<Array<{id:string;[key:string]:unknown}>>}
  */
 function getPageStories(features) {
   /**

--- a/src/StoryWrightProcessor/PlayWrightExecutor.ts
+++ b/src/StoryWrightProcessor/PlayWrightExecutor.ts
@@ -313,7 +313,7 @@ export class PlayWrightExecutor {
   public hover = async (selector: string) => {
     try {
       selector = this.curateSelector(selector);
-      const element = await this.page.$(selector);
+      const element = await this.page.waitForSelector(selector);
       await element.hover({
         force: true,
       });

--- a/src/StoryWrightProcessor/PlayWrightExecutor.ts
+++ b/src/StoryWrightProcessor/PlayWrightExecutor.ts
@@ -156,8 +156,7 @@ export class PlayWrightExecutor {
   public async processStory() {
     const steps = this.story.steps;
     try {
-      console.info(`Execute steps for story-id:${this.story.id}`)
-      await StepsExecutor.executesteps(steps, this);
+      await StepsExecutor.executesteps(steps, this, this.story.id);
     } catch (err) {
       console.error("ERROR: completed steps: ", err.message);
       throw err;

--- a/src/StoryWrightProcessor/PlayWrightExecutor.ts
+++ b/src/StoryWrightProcessor/PlayWrightExecutor.ts
@@ -155,8 +155,17 @@ export class PlayWrightExecutor {
 
   public async processStory() {
     const steps = this.story.steps;
+
     try {
-      await StepsExecutor.executesteps(steps, this, this.story.id);
+      if (steps === null || steps === undefined || steps.length == 0) {
+        await this.makeScreenshot();
+        await this.done();
+        return;
+      }
+
+      console.info(`steps: ${this.story.id} - start`);
+      await StepsExecutor.executesteps(steps, this);
+      console.info(`steps: ${this.story.id} - end`);
     } catch (err) {
       console.error("ERROR: completed steps: ", err.message);
       throw err;

--- a/src/StoryWrightProcessor/PlayWrightExecutor.ts
+++ b/src/StoryWrightProcessor/PlayWrightExecutor.ts
@@ -3,7 +3,7 @@ import { Page } from "playwright";
 import { sep } from "path";
 import { StoryWrightOptions } from "./StoryWrightOptions";
 import { StepsExecutor } from "./StepsExecutor";
-import type { Step } from "../StoryWright/Steps";
+import type { Story } from "../utils";
 /**
  * Class containing playwright exposed functions.
  */
@@ -26,7 +26,7 @@ export class PlayWrightExecutor {
     private ssNamePrefix: string,
     private browserName: string,
     private options: StoryWrightOptions,
-    private story: {steps?: Step[]}
+    private story: Story
   ) {
   }
 
@@ -156,6 +156,7 @@ export class PlayWrightExecutor {
   public async processStory() {
     const steps = this.story.steps;
     try {
+      console.info(`Execute steps for story-id:${this.story.id}`)
       await StepsExecutor.executesteps(steps, this);
     } catch (err) {
       console.error("ERROR: completed steps: ", err.message);

--- a/src/StoryWrightProcessor/StepsExecutor.ts
+++ b/src/StoryWrightProcessor/StepsExecutor.ts
@@ -7,16 +7,8 @@ import type { Step } from "../StoryWright/Steps";
  * Functions exposed in browser context called from React component.
  */
 export class StepsExecutor {
-  public static async executesteps(steps: Step[], executor: PlayWrightExecutor, _storyId:string) {
+  public static async executesteps(steps: Step[], executor: PlayWrightExecutor) {
 
-    console.info(`steps: ${_storyId} - initiate execution`);
-
-    if (steps === null || steps === undefined || steps.length == 0) {
-      console.info(`steps: ${_storyId} - no Steps defined - creating default story screenshot`);
-      await executor.makeScreenshot();
-      await executor.done();
-      return;
-    }
     if (steps[0]["type"] !== StepType.SaveScreenshot && steps[0]["type"] !== StepType.CropScreenshot) {
       await executor.makeScreenshot(steps[0].name);
     }

--- a/src/StoryWrightProcessor/StepsExecutor.ts
+++ b/src/StoryWrightProcessor/StepsExecutor.ts
@@ -7,10 +7,12 @@ import type { Step } from "../StoryWright/Steps";
  * Functions exposed in browser context called from React component.
  */
 export class StepsExecutor {
-  public static async executesteps(steps: Step[], executor: PlayWrightExecutor) {
+  public static async executesteps(steps: Step[], executor: PlayWrightExecutor, _storyId:string) {
+
+    console.info(`steps: ${_storyId} - initiate execution`);
 
     if (steps === null || steps === undefined || steps.length == 0) {
-      console.log(`Steps object is ${steps}`);
+      console.info(`steps: ${_storyId} - no Steps defined - creating default story screenshot`);
       await executor.makeScreenshot();
       await executor.done();
       return;

--- a/src/StoryWrightProcessor/StoryWrightOptions.ts
+++ b/src/StoryWrightProcessor/StoryWrightOptions.ts
@@ -12,4 +12,5 @@ export interface StoryWrightOptions {
   totalPartitions: number;
   waitTimeScreenshot: number;
   excludePatterns: Array<string>;
+  bailOnStoriesError: boolean
 }

--- a/src/StoryWrightProcessor/StoryWrightProcessor.ts
+++ b/src/StoryWrightProcessor/StoryWrightProcessor.ts
@@ -64,6 +64,10 @@ export class StoryWrightProcessor {
             );
             console.warn(errors.join('\n'));
             console.warn('-'.repeat(60),'\n');
+
+            if(options.bailOnStoriesError){
+              process.exit(1)
+            }
           }
 
         } catch (err) {

--- a/src/StoryWrightProcessor/StoryWrightProcessor.ts
+++ b/src/StoryWrightProcessor/StoryWrightProcessor.ts
@@ -3,7 +3,7 @@ import { Browser, BrowserContext, Page } from "playwright";
 import { BrowserUtils } from "./BrowserUtils";
 import { PlayWrightExecutor } from "./PlayWrightExecutor";
 import { StoryWrightOptions } from "./StoryWrightOptions";
-import { partitionArray } from "../utils";
+import { partitionArray, Story } from "../utils";
 import { readFileSync, existsSync } from "fs";
 
 /**
@@ -45,14 +45,15 @@ export class StoryWrightProcessor {
         });
 
         await page.goto(join(STORY_URL, "iframe.html"));
-        let stories: object[];
+
+        let stories: Story[];
         try {
           const getStoriesScript = readFileSync(
             join(__dirname, "GetStories.js"),
             "utf8"
           );
           const { storiesWithSteps, errors } = await page.evaluate<{
-            storiesWithSteps: { [key: string]: unknown; id: string }[];
+            storiesWithSteps: Story[];
             errors: string[];
           }>(getStoriesScript);
           stories = storiesWithSteps;
@@ -115,9 +116,9 @@ export class StoryWrightProcessor {
             position + options.concurrency
           );
           await Promise.all(
-            itemsForBatch.map(async (story: object) => {
-              const id: string = story["id"];
-              const tags: string = story["tags"];
+            itemsForBatch.map(async (story: Story) => {
+              const id = story["id"];
+              const tags = story["tags"];
               if (tags && tags.includes("no-screenshot")) {
                 console.log(
                   `StoryId: ${id} has tag no-screenshot hence skipping.`

--- a/src/StoryWrightProcessor/StoryWrightProcessor.ts
+++ b/src/StoryWrightProcessor/StoryWrightProcessor.ts
@@ -58,11 +58,14 @@ export class StoryWrightProcessor {
           stories = storiesWithSteps;
 
           if (errors.length) {
+            console.warn('-'.repeat(60));
             console.warn(
-              `[${errors.length}] errors occurred while processing Stories to obtain Steps definitions:`
+              `🚨 [${errors.length}] errors occurred while processing Stories to obtain Steps definitions:\n`
             );
-            console.warn(errors);
+            console.warn(errors.join('\n'));
+            console.warn('-'.repeat(60),'\n');
           }
+
         } catch (err) {
           // If getting stories from ifram.html is not sucessfull for storybook 7, try to get stories from stories.json
           // NOTE: this wont process Steps !

--- a/src/StoryWrightProcessor/StoryWrightProcessor.ts
+++ b/src/StoryWrightProcessor/StoryWrightProcessor.ts
@@ -203,6 +203,10 @@ export class StoryWrightProcessor {
                 console.log(
                   `**ERROR** for story ${ssNamePrefix} ${story["id"]} ${storyIndex}/${stories.length} ${err}`
                 );
+
+                if(options.bailOnStoriesError){
+                  process.exit(1);
+                }
               } finally {
                 if (context != null) {
                   await context.close();

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,12 @@ const args = argv
     nargs: 1,
     type: "number",
   })
+  .option("bailOnStoriesError", {
+    default: false,
+    describe:
+      "Fail process without taking any screenshot if any errors occurred while processing Stories.",
+    type: "boolean",
+  })
   .strict(true)
   .argv;
 
@@ -128,7 +134,8 @@ const storyWrightOptions: StoryWrightOptions = {
   partitionIndex: args.partitionIndex,
   totalPartitions: args.totalPartitions,
   waitTimeScreenshot: args.waitTimeScreenshot,
-  excludePatterns: args.excludePatterns
+  excludePatterns: args.excludePatterns,
+  bailOnStoriesError: args.bailOnStoriesError
 };
 
 StoryWrightProcessor.process(storyWrightOptions);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,22 @@ import { BrowserName } from "./StoryWrightProcessor/Constants";
 import { StoryWrightOptions } from "./StoryWrightProcessor/StoryWrightOptions";
 import { StoryWrightProcessor } from "./StoryWrightProcessor/StoryWrightProcessor";
 //import { resolve } from "path";
-import {cpus} from "os";
+import { cpus } from "os";
 
 const args = argv
+  .help()
+  .alias("help", "h")
   .usage("Usage: $0 [options]")
-  .help("h")
-  .alias("h", "help")
+  .example([
+    [
+    "$0",
+    "Captures screenshot for all stories using default static storybook path dist/iframe.html"
+    ],
+    [
+    "$0 -url https://localhost:5555 --browsers chromium",
+    "Captures screenshot for all stories from given storybook url for chromium browser"
+    ]
+  ])
   .option("url", {
     alias: "storybookurl",
     default: "dist",
@@ -26,7 +36,6 @@ const args = argv
     type: "string",
   })
   .option("browsers", {
-    alias: "browsers",
     default: [BrowserName.Chromium, BrowserName.Firefox],
     describe: "Comma seperated list of browsers to support",
     nargs: 1,
@@ -37,7 +46,6 @@ const args = argv
     choices: [BrowserName.Chromium, BrowserName.Firefox, BrowserName.Webkit],
   })
   .option("excludePatterns", {
-    alias: "excludePatterns",
     default: [BrowserName.Chromium, BrowserName.Firefox],
     describe: "Comma seperated list of StoryName regex pattern to be excluded",
     nargs: 1,
@@ -47,7 +55,6 @@ const args = argv
     }
   })
   .option("headless", {
-    alias: "headless",
     default: false,
     describe:
       "True if browser needs to be launched in headless mode else false",
@@ -67,14 +74,12 @@ const args = argv
     type: "number",
   })
   .option("concurrency", {
-    alias: "concurrency",
     default: 8,
     describe: "Number of browser tabs to open in parallel",
     nargs: 1,
     type: "number",
   })
   .option("skipSteps", {
-    alias: "skipSteps",
     default: false,
     describe:
       "Take Screenshot of all Storybook stories with/without wrapped component",
@@ -89,14 +94,9 @@ const args = argv
     nargs: 1,
     type: "number",
   })
-  .example(
-    "$0",
-    "Captures screenshot for all stories using default static storybook path dist/iframe.html"
-  )
-  .example(
-    "$0 -url https://localhost:5555 --browsers chromium",
-    "Captures screenshot for all stories from given storybook url for chromium browser"
-  ).argv;
+  .strict(true)
+  .argv;
+
 
 // When http(s) storybook url is passed no modification required.
 // When file path is provided it needs to be converted to absolute path and file:/// needs to be added to support firefox browser.

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ const args = argv
   .option("bailOnStoriesError", {
     default: false,
     describe:
-      "Fail process without taking any screenshot if any errors occurred while processing Stories.",
+      "Fail process if errors occurred while processing Stories or during making screenshots. Useful to make sure that your VR Test are valid and in CI scenarios.",
     type: "boolean",
   })
   .strict(true)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,3 +8,16 @@ export const partitionArray = <T>(
   const startingIndex = (partitionIndex - 1) * elementsInEachPartition;
   return array.slice(startingIndex, startingIndex + elementsInEachPartition);
 };
+
+export interface Story {
+  id: string;
+  tags: string[];
+  name: string;
+  kind: string;
+  parameters?: { [name: string]: any } & Partial<
+    import("./StoryWright/Steps").StoryParameter
+  >;
+  steps?: import('./StoryWright/Steps').Step[];
+  storyFn?: () => unknown;
+  [key: string]: unknown;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,9 +14,7 @@ export interface Story {
   tags: string[];
   name: string;
   kind: string;
-  parameters?: { [name: string]: any } & Partial<
-    import("./StoryWright/Steps").StoryParameter
-  >;
+  parameters?:  import("./StoryWright/Steps").StoryParameters;
   steps?: import('./StoryWright/Steps').Step[];
   storyFn?: () => unknown;
   [key: string]: unknown;


### PR DESCRIPTION
## Fixes:

### false positives about `Steps` presence and execution

fixes false positives regarding story missing Steps definition. 

Previously `.steps` property was always set on `story` because of logical error. 

With this fix `.step` will exist on processed story only IFF a story really defines `Steps` 

### proper `--help` output

<img width="725" alt="image" src="https://github.com/user-attachments/assets/71ed0a1f-5851-4a8a-a4e8-0b50c7a2b4c0" />

## Features:

### new API for defining `Steps`

This API should be used going forward as it supports various use-cases and Storybook version beyond v8

**Before:**

```ts
import {StoryWright, Steps} from 'storywright';
import {Button} from 'ui'

export default {
  component: Button,
  decorators: [ 
    (Story)=>{
       return <StoryWright steps={new Steps().snapshot('default').end()}>{ Story() }</StoryWright>
    }
  ]
}
```

**After:**

```ts
import {Steps, type StoryParameter} from 'storywright';
import {Button} from 'ui'

export default {
  component: Button,
  parameters: {
   storyWright: { 
       steps: new Steps().snapshot('default').end()
   }
  } satisfies StoryParameter
}

```

### new CLI flag `--bailOnStoriesError`

>💡 This is very useful for CI/CD pipelines to fail if there are any issues with stories or SW and Storybook stories fetching pipeline.

fails SW process in 2 places if enables:

**1. errors occurred while processing stories -> it will exit process immediately.**

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/82e12669-a47d-4609-ac89-b10c4684405d" />

**2. errors occurred during creating snapshots images per story**
 
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/69d18721-6c69-4869-b8af-87623b5a81c4" />



### new notification about issues that occurred while processing stories for Steps

previously these issues were consumed within page evaluation which consumer never received

<img width="796" alt="image" src="https://github.com/user-attachments/assets/91330ebd-6169-4f11-b095-fcc4909cbfb6" />

### improved Steps execution logging

**Before:**

<img width="849" alt="image" src="https://github.com/user-attachments/assets/8fb91ef4-80f2-4abb-afed-55dd300a13f0" />


**After:**

<img width="809" alt="image" src="https://github.com/user-attachments/assets/1047f5e0-6a86-483b-a3b4-1c0f54534dca" />



## Related Issues

- https://github.com/microsoft/fluentui/issues/33861
- Closes 
  - https://github.com/microsoft/storywright/issues/68
  - https://github.com/microsoft/storywright/issues/51
