### PR TITLE
fix: properly process result of extract() which is an object instead of array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "storywright",
-  "version": "0.0.27-storybook7.13",
+  "version": "0.0.27-storybook7.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "storywright",
-      "version": "0.0.27-storybook7.13",
+      "version": "0.0.27-storybook7.14",
       "license": "MIT",
       "dependencies": {
         "playwright": "^1.34.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "storywright",
   "description": "Storybook setup.",
   "license": "MIT",
-  "version": "0.0.27-storybook7.13",
+  "version": "0.0.27-storybook7.14",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/StoryWrightProcessor/GetStoriesV2.js
+++ b/src/StoryWrightProcessor/GetStoriesV2.js
@@ -5,14 +5,14 @@ getStoriesWithSteps();
 function getStoriesWithSteps() {
   return getPageStories().then((stories) => {
     /**
-     * @type {typeof stories}
+     * @type {Array<import('../utils').Story>}
      */
     const storiesWithSteps = [];
     /**
      * @type {string[]} story ids that failed while processing parameters
      */
     const errors = [];
-    for (let story of stories) {
+    for (let story of Object.values(stories)) {
       try {
         const steps = story.parameters?.storyWright.steps;
         if (Array.isArray(steps)) {
@@ -33,7 +33,7 @@ function getStoriesWithSteps() {
 
 /**
  *
- * @returns {Promise<Array<import('../utils').Story>>}
+ * @returns {Promise<{[story_id:string]: import('../utils').Story}>}
  */
 function getPageStories() {
   return window["__STORYBOOK_PREVIEW__"].extract();


### PR DESCRIPTION
## Needs 
- [x] https://github.com/microsoft/storywright/pull/75

## Changes

when `--stepsApi=parameters` is used stories processing works as expected

## Related Issues

- Follows https://github.com/microsoft/storywright/pull/74