### PR TITLE
fix: add wait for Storybook Preview API in stepsApi option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "storywright",
   "description": "Storybook setup.",
   "license": "MIT",
-  "version": "0.0.27-storybook7.14",
+  "version": "0.0.27-storybook7.15",
   "main": "lib/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/StoryWrightProcessor/GetStoriesV2.js
+++ b/src/StoryWrightProcessor/GetStoriesV2.js
@@ -14,7 +14,7 @@ function getStoriesWithSteps() {
     const errors = [];
     for (let story of Object.values(stories)) {
       try {
-        const steps = story.parameters?.storyWright.steps;
+        const steps = story.parameters?.storyWright?.steps;
         if (Array.isArray(steps)) {
           story.steps = steps;
         }

--- a/src/StoryWrightProcessor/StoryWrightProcessor.ts
+++ b/src/StoryWrightProcessor/StoryWrightProcessor.ts
@@ -54,6 +54,15 @@ export class StoryWrightProcessor {
           };
           const getStoriesScriptPath = scriptKind[options.stepsApi];
           const getStoriesScript = readFileSync(getStoriesScriptPath, "utf8");
+
+          if (options.stepsApi === "parameters") {
+            // Wait for Storybook Preview API to be available
+            // it's used in GetStoriesV2.js to access story parameters
+            await page.waitForFunction(() => {
+              return window["__STORYBOOK_PREVIEW__"];
+            });
+          }
+
           const { storiesWithSteps, errors } = await page.evaluate<{
             storiesWithSteps: Story[];
             errors: string[];


### PR DESCRIPTION
Added a check to wait for `window["__STORYBOOK_PREVIEW__"]` to be available when `options.stepsApi` is set to `"parameters"`, ensuring that dependent scripts execute only after the Storybook Preview API is ready.


This change unblocks the Storybook v8 migration for FluentUI https://github.com/microsoft/fluentui/pull/35279

The problem we encounter atm:

```
$ storywright --browsers chromium --url dist/storybook --destpath dist/screenshots --waitTimeScreenshot 500 --concurrency 4 --headless true --stepsApi parameters
================ StoryWright params =================
Storybook url = dist/storybook
Screenshot destination path = dist/screenshots
Browsers = chromium
Headless = true
Concurrency = 4
Cores available on system  = 16
SkipSteps = false
WaitTimeScreenshot = 500
ExcludePatterns = chromium,firefox
================ Starting story right execution =================
StoryWright processor started @  2025-10-22T15:57:09.921Z
Starting browser test for chromium
stories.json not found at /fluentui/apps/vr-tests-web-components/dist/storybook/stories.json
** ERROR ** Error: page.evaluate: SB_PREVIEW_API_0005 (CalledPreviewMethodBeforeInitializationError): Called `Preview.extract()` before initialization.

The preview needs to load the story index before most methods can be called. If you want
to call `extract`, try `await preview.initializationPromise;` first.

If you didn't call the above code, then likely it was called by an addon that needs to
do the above.
    at ns.extract (https://stories/sb-preview/runtime.js:6865:13)
    at getPageStories (eval at evaluate (:234:30), <anonymous>:37:44)
    at getStoriesWithSteps (eval at evaluate (:234:30), <anonymous>:4:12)
    at eval (eval at evaluate (:234:30), <anonymous>:2:1)
    at eval (<anonymous>)
    at UtilityScript.evaluate (<anonymous>:234:30)
    at UtilityScript.<anonymous> (<anonymous>:1:44)
Closing process !!
StoryWright took  1 secs to complete.
StoryWright processor completed @  2025-10-22T15:57:10.511Z
```


Related to #74